### PR TITLE
install_info_linux

### DIFF
--- a/doc/content/installing.rst
+++ b/doc/content/installing.rst
@@ -45,7 +45,16 @@ Staying up-to-date using setup.py::
 
 Dependencies
 ------------
-- numpy, scipy, and matplotlib beyond default python packages
+- NumPy, SciPy, and Matplotlib beyond default python packages
+
+- Fortran and the algebra libraries blas and lapack. For example,
+
+  - on Fedora::
+
+  sudo dnf install gcc-gfortran
+  sudo dnf install blas-dev
+  sudo dnf install lapack-dev
+
 
 .. warning:: pyCATHY for Data Assimilation relies on others libraries 
 


### PR DESCRIPTION
Hi Ben, I added some initial notes on how to install it on Fedora. We can then check how the algebra libraries are called on Ubuntu, maybe libblas-dev and liblapack-dev, and add that too (surely Ubuntu is more common and should be well documented).


